### PR TITLE
Allow wrap-start and wrap-end options to be functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,16 +40,16 @@ grunt.initConfig({
 ### Options
 
 #### options.wrap-start
-Type: `String`
+Type: `String|Function`
 Default value: `'var tpl = '`
 
-Template wrapper beginning
+Template wrapper beginning or a function which returns it.
 
 #### options.wrap-end
-Type: `String`
+Type: `String|Function`
 Default value: `';'`
 
-Template wrapper end
+Template wrapper end or a function which returns it.
 
 ### Usage Examples
 
@@ -84,6 +84,27 @@ grunt.initConfig({
       dest: 'build/',
       ext: '.js'
     }],
+  },
+})
+```
+
+#### options.wrap-start as function
+Use the template filename in the template wrapper beginning.
+
+```js
+grunt.initConfig({
+  swig_compile: {
+    options: {
+      "wrap-start": function(filepath){
+        // get template filename
+        var name = require('path').basename(filepath, '.swig');
+        //
+        return 'var tpl_' + name + ' = ';
+      }
+    },
+    files: {
+      'dest/compiled.js': ['**/*.swig'],
+    },
   },
 })
 ```

--- a/tasks/swig_compile.js
+++ b/tasks/swig_compile.js
@@ -38,10 +38,12 @@ module.exports = function(grunt) {
 					return true;
 				}
 			}).map(function(filepath) {
+        var wrapStart = typeof options['wrap-start'] === 'function'? options['wrap-start'].call(grunt, filepath): options['wrap-start'];
+        var wrapEnd = typeof options['wrap-end'] === 'function'? options['wrap-end'].call(grunt, filepath): options['wrap-end'];
 				// Read file source.
-				return options['wrap-start'] +
+				return wrapStart +
 						swig.precompile(grunt.file.read(filepath), { filename: filepath, locals: options.locals }).tpl.toString().replace('anonymous', '') +
-						options['wrap-end']
+					  wrapEnd
 				;
 			}).join(grunt.util.normalizelf(options.separator));
 


### PR DESCRIPTION
When compiling multiple files you can set a specific options.wrap-start for each file.
